### PR TITLE
closes #10

### DIFF
--- a/api/src/clients/evm.py
+++ b/api/src/clients/evm.py
@@ -1,22 +1,32 @@
+import asyncio
+
 from web3 import Web3
 
+from events.startup import warming_nonce
 from utils.logger import get_app_logger
-from config.misc import redis
+from config.misc import redis, w3
 from config.settings import settings
 from utils.redisdb import ADDRESS_NONCE_KEY
 
 logger = get_app_logger()
+lock = asyncio.Lock()
 
-w3 = Web3(Web3.HTTPProvider(settings.INFURA_HTTPS_ENDPOINT, request_kwargs={'timeout': 60}))
 
-
-async def warming_nonce():
-    nonce = w3.eth.get_transaction_count(Web3.toChecksumAddress(settings.ETHEREUM_PUBLIC_ADDRESS))
-    await redis.set(ADDRESS_NONCE_KEY, nonce)
+def _is_transaction_nonce_low(web3_error) -> bool:
+    if not len(web3_error.args):
+        return False
+    args = web3_error.args[0]
+    if args.get('message') and args['message'] == 'nonce too low':
+        return True
+    return False
 
 
 async def crypto_book(receiver_address: str, nft_contract: str, nft_token: str) -> str:
-    """Returns transaction hex."""
+    """Returns transaction hex.
+    Note that we want to allow retry on wrong nonce and implement such continues retry policy.
+    The issue comes when private key is used in external from app manner - directly from metamask e.g.
+    (ref to https://github.com/whynft/nft-gift-button-backend/issues/10).
+    """
     contract = w3.eth.contract(
         address=Web3.toChecksumAddress(settings.DARILKA_CONTRACT_ADDRESS),
         abi=settings.DARILKA_CONTRACT_ABI_JSON,
@@ -44,7 +54,14 @@ async def crypto_book(receiver_address: str, nft_contract: str, nft_token: str) 
 
     signed_txn = w3.eth.account.signTransaction(txn_dict, private_key=settings.ETHEREUM_PRIVATE_KEY)
 
-    transaction = w3.eth.sendRawTransaction(signed_txn.rawTransaction)
-    logger.debug(f'Sent transaction to EMV, got {transaction.hex()}.')
+    try:
+        transaction = w3.eth.sendRawTransaction(signed_txn.rawTransaction)
+    except ValueError as e:
+        if _is_transaction_nonce_low(e):
+            async with lock:
+                await warming_nonce()
+            return await crypto_book(receiver_address, nft_contract, nft_token)
+        raise(e)
 
+    logger.debug(f'Sent transaction to EMV, got transaction = {transaction.hex()}.')
     return transaction.hex()

--- a/api/src/config/misc.py
+++ b/api/src/config/misc.py
@@ -1,5 +1,7 @@
 import aioredis
+from web3 import Web3
 
 from config.settings import settings
 
 redis = aioredis.from_url(f'redis://{settings.REDIS_HOST}:{settings.REDIS_PORT}', db=0, decode_responses=True)
+w3 = Web3(Web3.HTTPProvider(settings.INFURA_HTTPS_ENDPOINT, request_kwargs={'timeout': 60}))

--- a/api/src/events/startup.py
+++ b/api/src/events/startup.py
@@ -1,0 +1,10 @@
+from web3 import Web3
+
+from config.misc import w3, redis
+from config.settings import settings
+from utils.redisdb import ADDRESS_NONCE_KEY
+
+
+async def warming_nonce():
+    nonce = w3.eth.get_transaction_count(Web3.toChecksumAddress(settings.ETHEREUM_PUBLIC_ADDRESS))
+    await redis.set(ADDRESS_NONCE_KEY, nonce)

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -27,7 +27,7 @@ app.add_middleware(
 
 @app.on_event("startup")
 async def startup_event():
-    from clients.evm import warming_nonce
+    from events.startup import warming_nonce
 
     logger.info("Prepare and initiate nonce according to the chain...")
     await warming_nonce()


### PR DESCRIPTION
when we identify (before it was a simple exception in code - kinda bag of external cause) that nonce is too low (e.g. someone used private key in metamask) - we merely proceed an action as it goes on app's startup: ask evm about current nonce and save the value into redis to use on the next steps

as well I refactored proj structure a bit